### PR TITLE
Fix calculation for progress steps

### DIFF
--- a/lib/generate-critical-css.js
+++ b/lib/generate-critical-css.js
@@ -14,7 +14,7 @@ async function generateCriticalCSS( {
 	}
 
 	try {
-		const progressSteps = 1 + urls.length + viewports.length;
+		const progressSteps = 1 + urls.length * viewports.length;
 		let progress = 0;
 
 		// Gather all CSS files used by all URLs.


### PR DESCRIPTION
Progress gets bumped inside a double-loop `urls` and `viewports`. So, the steps calculation should reflect that; `urls.length * viewports.length`. This PR fixes that calculation.