### PR TITLE
Add an allowScripts flag

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export declare class BrowserInterfaceIframe implements BrowserInterface {
 		loadTimeout?: number,
 		resizeTimeout?: number,
 		verifyPage?: ( url: string, contentWindow: Window, contentDocument: Document ) => boolean,
+		allowScripts?: boolean, // Defaults to true if unspecified.
 	} );
 }
 

--- a/lib/browser-interface-iframe.js
+++ b/lib/browser-interface-iframe.js
@@ -17,6 +17,7 @@ class BrowserInterfaceIframe extends BrowserInterface {
 		loadTimeout,
 		resizeTimeout,
 		verifyPage,
+		allowScripts,
 	} = {} ) {
 		super();
 
@@ -24,6 +25,9 @@ class BrowserInterfaceIframe extends BrowserInterface {
 		this.loadTimeout = loadTimeout || defaultLoadTimeout;
 		this.resizeTimeout = resizeTimeout || defaultResizeTimeout;
 		this.verifyPage = verifyPage;
+
+		// Default 'allowScripts' to true if not specified.
+		allowScripts = ( allowScripts !== false );
 
 		if ( ! verifyPage ) {
 			throw new ConfigurationError( {
@@ -51,7 +55,7 @@ class BrowserInterfaceIframe extends BrowserInterface {
 		this.iframe.setAttribute( 'aria-hidden', 'true' );
 		this.iframe.setAttribute(
 			'sandbox',
-			'allow-same-origin allow-scripts'
+			'allow-same-origin ' + ( allowScripts ? 'allow-scripts' : '' )
 		);
 		this.wrapperDiv.append( this.iframe );
 	}

--- a/tests/data/page-a/index.html
+++ b/tests/data/page-a/index.html
@@ -9,5 +9,9 @@
 		<div class="top"></div>
 		<div class="four_eighty"></div>
 		<div class="eight_hundred"></div>
+
+		<script>
+			document.writeln( [ 'script', 'created', 'content' ].join( '-' ) );
+		</script>
 	</body>
 </html>

--- a/tests/unit/browser-interface-iframe.test.js
+++ b/tests/unit/browser-interface-iframe.test.js
@@ -1,4 +1,4 @@
-/* global browser */
+/* global browser, TestGenerator */
 
 const path = require( 'path' );
 const TestServer = require( '../lib/test-server' );
@@ -31,8 +31,6 @@ describe( 'Iframe interface', () => {
 		const innerUrl = path.join( testServer.getUrl(), 'page-a' );
 
 		const [ css, warnings ] = await page.evaluate( ( url ) => {
-			/* global TestGenerator */
-
 			return TestGenerator.generateCriticalCSS( {
 				urls: [ url ],
 				viewports: [ { width: 640, height: 480 } ],
@@ -40,6 +38,74 @@ describe( 'Iframe interface', () => {
 					verifyPage: ( url, innerWindow, innerDocument) => {
 						return !! innerDocument.querySelector( 'meta[name="testing-page"]' );
 					}
+				} ),
+			} );
+		}, innerUrl );
+
+		expect( warnings ).toHaveLength( 0 );
+		expect( css ).toContain( 'div.top' );
+
+		await page.close();
+	} );
+
+	it( 'Allows scripts if not explicitly turned off', async () => {
+		const page = await browser.newPage();
+		await page.goto( testServer.getUrl() );
+
+		const innerUrl = path.join( testServer.getUrl(), 'page-a' );
+
+		// Will throw an error if the inner page does not contain
+		// 'script-created-content'; a string appended to page-a by a script.
+		await page.evaluate( async ( url ) => {
+			const iframeInterface = new TestGenerator.BrowserInterfaceIframe( {
+				verifyPage: ( url, innerWindow, innerDocument) => {
+					return innerDocument.documentElement.innerHTML.includes( 'script-created-content' );
+				}
+			} )
+
+			await iframeInterface.loadPage( url );
+		}, innerUrl );
+
+		await page.close();
+	} );
+
+	it( 'Blocks scripts if turned off', async () => {
+		const page = await browser.newPage();
+		await page.goto( testServer.getUrl() );
+
+		const innerUrl = path.join( testServer.getUrl(), 'page-a' );
+
+		// Will throw an error if the inner page contains
+		// 'script-created-content'; a string appended to page-a by a script.
+		await page.evaluate( async ( url ) => {
+			const iframeInterface = new TestGenerator.BrowserInterfaceIframe( {
+				verifyPage: ( url, innerWindow, innerDocument) => {
+					return ! innerDocument.documentElement.innerHTML.includes( 'script-created-content' );
+				},
+				allowScripts: false,
+			} )
+
+			await iframeInterface.loadPage( url );
+		}, innerUrl );
+
+		await page.close();
+	} );
+
+	it( 'Can successfully generate using an iframe with JavaScript off', async () => {
+		const page = await browser.newPage();
+		await page.goto( testServer.getUrl() );
+
+		const innerUrl = path.join( testServer.getUrl(), 'page-a' );
+
+		const [ css, warnings ] = await page.evaluate( ( url ) => {
+			return TestGenerator.generateCriticalCSS( {
+				urls: [ url ],
+				viewports: [ { width: 640, height: 480 } ],
+				browserInterface: new TestGenerator.BrowserInterfaceIframe( {
+					verifyPage: ( url, innerWindow, innerDocument) => {
+						return !! innerDocument.querySelector( 'meta[name="testing-page"]' );
+					},
+					allowScripts: false,
 				} ),
 			} );
 		}, innerUrl );


### PR DESCRIPTION
Add an 'allowScripts' flag to `BrowserInterfaceIframe`, allowing callers to explicitly turn off scripts in the inner iframe. This new flag defaults to `true` if unspecified.

e.g.:
```
const [ css, warnings ] = await generateCriticalCSS( {
	urls: [ url ],
	viewports: [ { width: 640, height: 480 } ],
	browserInterface: new TestGenerator.BrowserInterfaceIframe( {
		...
		allowScripts: false,
	} ),
} );
```

New tests have been added to verify the functionality works as expected.