### PR TITLE
Simplify waiting for iframe resize to avoid child script issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,6 @@ export declare class BrowserInterfaceIframe implements BrowserInterface {
 	constructor( args?: {
 		requestGetParameters?: { [ key: string ]: string },
 		loadTimeout?: number,
-		resizeTimeout?: number,
 		verifyPage?: ( url: string, contentWindow: Window, contentDocument: Document ) => boolean,
 		allowScripts?: boolean, // Defaults to true if unspecified.
 	} );

--- a/lib/browser-interface-iframe.js
+++ b/lib/browser-interface-iframe.js
@@ -9,13 +9,11 @@ const {
 } = require( './errors' );
 
 const defaultLoadTimeout = 60 * 1000;
-const defaultResizeTimeout = 1 * 1000;
 
 class BrowserInterfaceIframe extends BrowserInterface {
 	constructor( {
 		requestGetParameters,
 		loadTimeout,
-		resizeTimeout,
 		verifyPage,
 		allowScripts,
 	} = {} ) {
@@ -23,7 +21,6 @@ class BrowserInterfaceIframe extends BrowserInterface {
 
 		this.requestGetParameters = requestGetParameters || {};
 		this.loadTimeout = loadTimeout || defaultLoadTimeout;
-		this.resizeTimeout = resizeTimeout || defaultResizeTimeout;
 		this.verifyPage = verifyPage;
 
 		// Default 'allowScripts' to true if not specified.
@@ -162,14 +159,8 @@ class BrowserInterfaceIframe extends BrowserInterface {
 			this.iframe.width = width;
 			this.iframe.height = height;
 
-			// Wait for an animation frame, indicating resize complete.
-			this.iframe.contentWindow.requestAnimationFrame( () => {
-				// After receiving an animation frame, bounce to main loop to ensure paint finished.
-				this.iframe.contentWindow.setTimeout( resolve, 1 );
-			} );
-
-			// Set a back-stop timeout; if it takes longer than a second, assume it's done.
-			setTimeout( resolve, this.resizeTimeout );
+			// Bounce to browser main loop to allow resize to complete.
+			setTimeout( resolve, 1 );
 		} );
 	}
 }


### PR DESCRIPTION
Using `requestAnimationFrame` in the child iframe to wait for a resize to complete won't work if JavaScript is disabled. This PR removes that requirement, instead just using `setTimeout` in the parent context to bounce back to the main loop and give the iframe a chance to finish laying itself out.