### PR TITLE
Take link media= rules into account

### DIFF
--- a/lib/browser-interface.js
+++ b/lib/browser-interface.js
@@ -10,18 +10,24 @@ class BrowserInterface {
 
 	async cleanup() {}
 
-	async getCssUrls( pageUrl ) {
+	async getCssIncludes( pageUrl ) {
 		return await this.runInPage(
 			pageUrl,
 			null,
-			BrowserInterface.innerGetCssUrls
+			BrowserInterface.innerGetCssIncludes
 		);
 	}
 
-	static innerGetCssUrls( window ) {
+	static innerGetCssIncludes( window ) {
 		return [ ...window.document.getElementsByTagName( 'link' ) ]
 			.filter( ( link ) => link.rel === 'stylesheet' )
-			.map( ( link ) => link.href );
+			.reduce( ( set, link ) => {
+				set[ link.href ] = {
+					media: link.media || null
+				};
+
+				return set;
+			}, {} );
 	}
 }
 

--- a/lib/css-file-set.js
+++ b/lib/css-file-set.js
@@ -20,14 +20,16 @@ class CSSFileSet {
 	}
 
 	/**
-	 * Add an array of CSS URLs from an HTML page to this set.
+	 * Add a set of CSS URLs from an HTML page to this set.
 	 *
 	 * @param {string} page - URL of the page the CSS URLs were found on.
-	 * @param {string[]} cssUrls - The CSS file URLs.
+	 * @param {Object} cssIncludes - Included CSS Files. Keyed by URL.
 	 */
-	async addMultiple( page, cssUrls ) {
+	async addMultiple( page, cssIncludes ) {
 		return Promise.all(
-			cssUrls.map( ( cssUrl ) => this.add( page, cssUrl ) )
+			Object.keys( cssIncludes ).map(
+				( url ) => this.add( page, url, cssIncludes[ url ] )
+			)
 		);
 	}
 
@@ -37,7 +39,7 @@ class CSSFileSet {
 	 * @param {string} page - URL of the page the CSS URL was found on.
 	 * @param {string} cssUrl - The CSS file URL.
 	 */
-	async add( page, cssUrl ) {
+	async add( page, cssUrl, settings = {} ) {
 		// Add by reference if we already know this file.
 		if ( Object.prototype.hasOwnProperty.call( this.knownUrls, cssUrl ) ) {
 			if ( this.knownUrls[ cssUrl ] instanceof Error ) {
@@ -56,7 +58,14 @@ class CSSFileSet {
 				throw new HttpError( { code: response.code, url: cssUrl } );
 			}
 
-			this.storeCss( page, cssUrl, await response.text() );
+			let css = await response.text();
+
+			// If there is an implied media query from the css's <link> tag, wrap the CSS in it.
+			if ( settings.media ) {
+				css = '@media ' + settings.media + ' {\n' + css + '\n}';
+			}
+
+			this.storeCss( page, cssUrl, css );
 		} catch ( err ) {
 			let wrappedError = err;
 
@@ -229,13 +238,20 @@ class CSSFileSet {
 		const cssFiles = new CSSFileSet();
 
 		for ( const url of urls ) {
-			const cssUrls = await browserInterface.getCssUrls( url );
+			const cssIncludes = await browserInterface.getCssIncludes( url );
+
+			// Convert relative URLs to absolute.
+			const relativeUrls = Object.keys( cssIncludes );
+			const absoluteIncludes = relativeUrls.reduce( ( set, relative ) => {
+				const absolute = new URL( relative, url ).toString();
+				set[ absolute ] = cssIncludes[ relative ];
+
+				return set;
+			}, {} );
 
 			await cssFiles.addMultiple(
 				url,
-				cssUrls.map( ( relative ) =>
-					new URL( relative, url ).toString()
-				)
+				absoluteIncludes
 			);
 		}
 

--- a/tests/data/page-a/complex-rules.css
+++ b/tests/data/page-a/complex-rules.css
@@ -1,0 +1,4 @@
+/* This rule is included using complex media="" rules, so should be appropriately wrapped */
+div.complex_media_rules {
+	color: purple;
+}

--- a/tests/data/page-a/index.html
+++ b/tests/data/page-a/index.html
@@ -4,6 +4,7 @@
 		<link rel="stylesheet" href="style.css" />
 		<link rel="stylesheet" href="print.css" media="print" />
 		<link rel="stylesheet" href="min-width.css" media="(min-width: 50px)" />
+		<link rel="stylesheet" type="text/css" media="only screen and (max-device-width: 480px) and (orientation: landscape)" href="complex-rules.css" />"
 		<meta name="testing-page" content="testing-page" />
 	</head>
 
@@ -13,6 +14,7 @@
 		<div class="eight_hundred"></div>
 		<div class="sir_not_appearing_in_this_film"></div>
 		<div class="min_width_screen"></div>
+		<div class="complex_media_rules"></div>
 
 		<script>
 			document.writeln( [ 'script', 'created', 'content' ].join( '-' ) );

--- a/tests/data/page-a/index.html
+++ b/tests/data/page-a/index.html
@@ -2,6 +2,8 @@
 	<head>
 		<title>Test page</title>
 		<link rel="stylesheet" href="style.css" />
+		<link rel="stylesheet" href="print.css" media="print" />
+		<link rel="stylesheet" href="min-width.css" media="(min-width: 50px)" />
 		<meta name="testing-page" content="testing-page" />
 	</head>
 
@@ -9,6 +11,8 @@
 		<div class="top"></div>
 		<div class="four_eighty"></div>
 		<div class="eight_hundred"></div>
+		<div class="sir_not_appearing_in_this_film"></div>
+		<div class="min_width_screen"></div>
 
 		<script>
 			document.writeln( [ 'script', 'created', 'content' ].join( '-' ) );

--- a/tests/data/page-a/min-width.css
+++ b/tests/data/page-a/min-width.css
@@ -1,0 +1,6 @@
+@media screen {
+	/* This rule should appear inside two media rules; min-width and screen */
+	div.min_width_screen {
+		color: pink;
+	}
+}

--- a/tests/data/page-a/print.css
+++ b/tests/data/page-a/print.css
@@ -1,0 +1,6 @@
+/* These rules are included in a media="print" link, and so should not be
+included in the end result, ever. */
+
+div.sir_not_appearing_in_this_film {
+	color: red;
+}

--- a/tests/unit/generate-critical-css.test.js
+++ b/tests/unit/generate-critical-css.test.js
@@ -105,6 +105,16 @@ describe( 'Generate Critical CSS', () => {
 				}
 			] );
 		} );
+
+		it( 'Can manage complex implicit @media rules inherited from <link> tags', async () => {
+			await runTestSet( [
+				{
+					shouldContain: [
+						'@media only screen and (max-device-width:480px) and (orientation:landscape){div.complex_media_rules{',
+					]
+				}
+			] );
+		} );
 	} );
 
 } );

--- a/tests/unit/generate-critical-css.test.js
+++ b/tests/unit/generate-critical-css.test.js
@@ -21,7 +21,7 @@ let testPages = {};
  * @param {Object[]} testSets Sets of tests to run, and strings the result should / should not contain.
  */
 async function runTestSet( testSets ) {
-	for ( const { urls, viewports, shouldContain, shouldNotContain } of testSets ) {
+	for ( const { urls, viewports, shouldContain, shouldNotContain, shouldMatch } of testSets ) {
 		const [ css, warnings ] = await generateCriticalCSS({
 			urls: urls || Object.values( testPageUrls ),
 			viewports: viewports || [ { width: 640, height: 480 } ],
@@ -36,6 +36,10 @@ async function runTestSet( testSets ) {
 
 		for ( const shouldNot of shouldNotContain || [] ) {
 			expect( css ).not.toContain( shouldNot );
+		}
+
+		for ( const regexp of shouldMatch || [] ) {
+			expect( css ).toMatch( regexp );
 		}
 	}
 }
@@ -84,6 +88,23 @@ describe( 'Generate Critical CSS', () => {
 			] );
 		} );
 
+		it( 'Excludes Critical CSS from a <link media="print"> tag', async () => {
+			await runTestSet( [
+				{
+					shouldNotContain: [ 'sir_not_appearing_in_this_film' ],
+				}
+			] );
+		} );
+
+		it( 'Includes implicit @media rules inherited from <link> tags', async () => {
+			await runTestSet( [
+				{
+					shouldMatch: [
+						/@media\s+\(\s*min-width:\s*50px\s*\)\s*{\s*@media\s+screen\s*{/
+					],
+				}
+			] );
+		} );
 	} );
 
 } );


### PR DESCRIPTION
`<link media="">` rules were not being taken into account when finding Critical CSS files to include in Critical CSS generation. Media rules can hide certain stylesheets from non-print media, or even affect which styles appear at different page widths.

This PR fixes the issue by adding the `media` rules from link elements as implied `@media ... { }` rules around the CSS being included.