### PR TITLE
Add logic to catch url redirects and raise an error

### DIFF
--- a/lib/browser-interface-iframe.js
+++ b/lib/browser-interface-iframe.js
@@ -5,6 +5,7 @@ const {
 	HttpError,
 	GenericUrlError,
 	LoadTimeoutError,
+	RedirectError,
 	UrlVerifyError,
 } = require( './errors' );
 
@@ -88,6 +89,9 @@ class BrowserInterfaceIframe extends BrowserInterface {
 		try {
 			const response = await fetch( url );
 			if ( response.status === 200 ) {
+				if ( response.redirected ) {
+					return new RedirectError( { url, redirectUrl: response.url } )
+				}
 				return null;
 			}
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -144,7 +144,7 @@ class RedirectError extends CriticalCssError {
 	}
 
 	static getMessage( data ) {
-		return `Failed to process ${ data.url } because it has an HTTP redirection to ${ data.redirectUrl }`;
+		return `Failed to process ${ data.url } because it redirects to ${ data.redirectUrl } which cannot be verified`;
 	}
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -136,6 +136,19 @@ class LoadTimeoutError extends CriticalCssError {
 }
 
 /**
+ * RedirectError - Indicates that a requested URL failed due to an HTTP redirection of that url.
+ */
+class RedirectError extends CriticalCssError {
+	constructor( { url, redirectUrl } ) {
+		super( RedirectError, { url, redirectUrl } );
+	}
+
+	static getMessage( data ) {
+		return `Failed to process ${ data.url } because it has an HTTP redirection to ${ data.redirectUrl }`;
+	}
+}
+
+/**
  * UrlVerifyError - Indicates that a provided BrowserInterface verifyUrl
  * callback returned false for a page which was otherwise loaded successfully.
  */
@@ -181,6 +194,7 @@ const CriticalCssErrorTypes = {
 	// Detailed errors
 	CrossDomainError,
 	LoadTimeoutError,
+	RedirectError,
 	HttpError,
 	UrlVerifyError,
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -110,7 +110,7 @@ class GenericUrlError extends CriticalCssError {
 
 /**
  * CrossDomainError - Indicates that a requested URL failed due to CORS / security
- * limtiations imposed by the browser.
+ * limitations imposed by the browser.
  */
 class CrossDomainError extends CriticalCssError {
 	constructor( { url } ) {


### PR DESCRIPTION
This PR adds a logic to catch url redirects and raise an error. 

We know that an HTTP redirect on the original url that we are trying to generate Critical CSS for does fail the process because the redirection url cannot pass the verify test. As a result we are sending back to the plugin a `UrlVerifyError` error.
Instead it could be better to raise a specific error related to the redirection so it can be bubble up to the plugin and acted upon. Basically on the plugin we could then ignore those redirected urls for subsequent Critical CSS generation as shown in this POC: https://cloudup.com/c_vmzVAhMa1