### PR TITLE
Tools to bundle with rollup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
 	},
 	"extends": [
 		"eslint:recommended"
-	]
+	],
+	"ignorePatterns": [ "dist/**" ]
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
+/dist
 .DS_Store

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ export interface CssFilters {
 export declare class CriticalCssError {
 	hasUrl(): boolean;
 	toJSON(): any;
+	get( key: string ): any;
 	static fromJSON: ( data: any ) => CriticalCssError;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ export declare class CriticalCssError {
 	hasUrl(): boolean;
 	toJSON(): any;
 	get( key: string ): any;
+	getType(): string;
 	static fromJSON: ( data: any ) => CriticalCssError;
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -11,7 +11,12 @@
  */
 class CriticalCssError extends Error {
 	constructor( type, data ) {
-		super( type.getMessage( data ) );
+		if ( ! CriticalCssErrorTypes[ type ] ) {
+			type = 'UnknownError';
+			data = { message: JSON.stringify( data ) };
+		}
+
+		super( CriticalCssErrorTypes[ type ].getMessage( data ) );
 
 		this.type = type;
 		this.data = data;
@@ -21,7 +26,7 @@ class CriticalCssError extends Error {
 	 * Returns the type of error as a string.
 	 */
 	getType() {
-		return this.type.name;
+		return this.type;
 	}
 
 	/**
@@ -44,9 +49,9 @@ class CriticalCssError extends Error {
 	 */
 	toJSON() {
 		return {
-			type: this.type.name,
+			type: this.type,
 			data: this.data,
-			message: this.type.getMessage( this.data ),
+			message: CriticalCssErrorTypes[ this.type ].getMessage( this.data ),
 		};
 	}
 
@@ -73,7 +78,7 @@ class CriticalCssError extends Error {
  */
 class UnknownError extends CriticalCssError {
 	constructor( { message } ) {
-		super( UnknownError, { message } );
+		super( 'UnknownError', { message } );
 	}
 
 	static getMessage( data ) {
@@ -86,7 +91,7 @@ class UnknownError extends CriticalCssError {
  */
 class HttpError extends CriticalCssError {
 	constructor( { url, code } ) {
-		super( HttpError, { url, code } );
+		super( 'HttpError', { url, code } );
 	}
 
 	static getMessage( data ) {
@@ -100,7 +105,7 @@ class HttpError extends CriticalCssError {
  */
 class GenericUrlError extends CriticalCssError {
 	constructor( { url, message } ) {
-		super( GenericUrlError, { url, message } );
+		super( 'GenericUrlError', { url, message } );
 	}
 
 	static getMessage( data ) {
@@ -114,7 +119,7 @@ class GenericUrlError extends CriticalCssError {
  */
 class CrossDomainError extends CriticalCssError {
 	constructor( { url } ) {
-		super( CrossDomainError, { url } );
+		super( 'CrossDomainError', { url } );
 	}
 
 	static getMessage( data ) {
@@ -127,7 +132,7 @@ class CrossDomainError extends CriticalCssError {
  */
 class LoadTimeoutError extends CriticalCssError {
 	constructor( { url } ) {
-		super( LoadTimeoutError, { url } );
+		super( 'LoadTimeoutError', { url } );
 	}
 
 	static getMessage( data ) {
@@ -140,7 +145,7 @@ class LoadTimeoutError extends CriticalCssError {
  */
 class RedirectError extends CriticalCssError {
 	constructor( { url, redirectUrl } ) {
-		super( RedirectError, { url, redirectUrl } );
+		super( 'RedirectError', { url, redirectUrl } );
 	}
 
 	static getMessage( data ) {
@@ -154,7 +159,7 @@ class RedirectError extends CriticalCssError {
  */
 class UrlVerifyError extends CriticalCssError {
 	constructor( { url } ) {
-		super( UrlVerifyError, { url } );
+		super( 'UrlVerifyError', { url } );
 	}
 
 	static getMessage( data ) {
@@ -168,7 +173,7 @@ class UrlVerifyError extends CriticalCssError {
  */
 class ConfigurationError extends CriticalCssError {
 	constructor( { message } ) {
-		super( ConfigurationError, { message } );
+		super( 'ConfigurationError', { message } );
 	}
 
 	static getMessage( data ) {
@@ -182,7 +187,7 @@ class ConfigurationError extends CriticalCssError {
  */
 class InternalError extends CriticalCssError {
 	constructor( { message } ) {
-		super( InternalError, { message } );
+		super( 'InternalError', { message } );
 	}
 
 	static getMessage( data ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -695,6 +695,69 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@rollup/plugin-commonjs": {
+			"version": "19.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.0.tgz",
+			"integrity": "sha512-adTpD6ATGbehdaQoZQ6ipDFhdjqsTgpOAhFiPwl+dzre4pPshsecptDPyEFb61JMJ1+mGljktaC4jI8ARMSNyw==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			}
+		},
+		"@rollup/plugin-json": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+			"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.0.8"
+			}
+		},
+		"@rollup/plugin-node-resolve": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
+			"integrity": "sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
+				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
+				"is-module": "^1.0.0",
+				"resolve": "^1.19.0"
+			}
+		},
+		"@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"dependencies": {
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+					"dev": true
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+					"dev": true
+				}
+			}
+		},
 		"@sinonjs/commons": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -842,6 +905,15 @@
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.6.tgz",
 			"integrity": "sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==",
 			"dev": true
+		},
+		"@types/resolve": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/stack-utils": {
 			"version": "2.0.0",
@@ -1115,6 +1187,23 @@
 			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
 		},
+		"abstract-leveldown": {
+			"version": "0.12.4",
+			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+			"integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+			"dev": true,
+			"requires": {
+				"xtend": "~3.0.0"
+			},
+			"dependencies": {
+				"xtend": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+					"dev": true
+				}
+			}
+		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1277,6 +1366,26 @@
 			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
+			}
+		},
+		"asn1.js": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
 			}
 		},
 		"assert-plus": {
@@ -1479,6 +1588,12 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"bn.js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+			"dev": true
+		},
 		"body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -1539,11 +1654,100 @@
 				"fill-range": "^7.0.1"
 			}
 		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"dev": true
+		},
 		"browser-process-hrtime": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
 			"dev": true
+		},
+		"browserify-aes": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"dev": true,
+			"requires": {
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"browserify-cipher": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+			"dev": true,
+			"requires": {
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
+			}
+		},
+		"browserify-des": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"browserify-fs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-fs/-/browserify-fs-1.0.0.tgz",
+			"integrity": "sha1-8HWqinKdTRcW0GZiDjhvzBMRqW8=",
+			"dev": true,
+			"requires": {
+				"level-filesystem": "^1.0.1",
+				"level-js": "^2.1.3",
+				"levelup": "^0.18.2"
+			}
+		},
+		"browserify-rsa": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+			"integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^5.0.0",
+				"randombytes": "^2.0.1"
+			}
+		},
+		"browserify-sign": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+			"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^5.1.1",
+				"browserify-rsa": "^4.0.1",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"elliptic": "^6.5.3",
+				"inherits": "^2.0.4",
+				"parse-asn1": "^5.1.5",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				}
+			}
 		},
 		"browserslist": {
 			"version": "4.16.3",
@@ -1583,10 +1787,28 @@
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
 			"dev": true
 		},
+		"buffer-es6": {
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/buffer-es6/-/buffer-es6-4.9.3.tgz",
+			"integrity": "sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ=",
+			"dev": true
+		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
+		},
+		"builtin-modules": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
 			"dev": true
 		},
 		"builtin-status-codes": {
@@ -1729,6 +1951,16 @@
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 			"dev": true
 		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"cjs-module-lexer": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
@@ -1776,6 +2008,12 @@
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^6.2.0"
 			}
+		},
+		"clone": {
+			"version": "0.1.19",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
+			"integrity": "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU=",
+			"dev": true
 		},
 		"clone-deep": {
 			"version": "0.2.4",
@@ -1859,6 +2097,12 @@
 			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
 			"dev": true
 		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
 		"compare-versions": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
@@ -1876,6 +2120,44 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
+		},
+		"concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
+			}
 		},
 		"content-disposition": {
 			"version": "0.5.3",
@@ -1944,6 +2226,51 @@
 				"yaml": "^1.10.0"
 			}
 		},
+		"create-ecdh": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.5.3"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
+			}
+		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1953,6 +2280,25 @@
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
+			}
+		},
+		"crypto-browserify": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+			"dev": true,
+			"requires": {
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
 			}
 		},
 		"css-tree": {
@@ -2056,6 +2402,15 @@
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
+		"deferred-leveldown": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+			"integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
+			"dev": true,
+			"requires": {
+				"abstract-leveldown": "~0.12.1"
+			}
+		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2109,6 +2464,16 @@
 			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
 			"dev": true
 		},
+		"des.js": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
 		"destroy": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -2132,6 +2497,25 @@
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
 			"integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
 			"dev": true
+		},
+		"diffie-hellman": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
+			}
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -2190,6 +2574,29 @@
 			"integrity": "sha512-j6pRuNylFBbroG6NB8Lw/Im9oDY74s2zWHBP5TmdYg73cBuL6cz//SMgolVa0gIJk/DSL+kO7baJ1DSXW1FUZg==",
 			"dev": true
 		},
+		"elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
+			}
+		},
 		"emittery": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
@@ -2241,6 +2648,15 @@
 			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.4.tgz",
 			"integrity": "sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==",
 			"dev": true
+		},
+		"errno": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+			"dev": true,
+			"requires": {
+				"prr": "~1.0.1"
+			}
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -2481,6 +2897,12 @@
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
+		"estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
+		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2498,6 +2920,16 @@
 			"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
 			"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
 			"dev": true
+		},
+		"evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
+			"requires": {
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
+			}
 		},
 		"exec-sh": {
 			"version": "0.3.4",
@@ -3053,6 +3485,12 @@
 				"for-in": "^1.0.1"
 			}
 		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3133,6 +3571,41 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
+		},
+		"fwd-stream": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz",
+			"integrity": "sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "~1.0.26-4"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -3379,6 +3852,46 @@
 				}
 			}
 		},
+		"hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				}
+			}
+		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"dev": true,
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -3538,6 +4051,12 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"idb-wrapper": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
+			"integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg==",
+			"dev": true
+		},
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3574,6 +4093,12 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
 			"dev": true
 		},
 		"inflight": {
@@ -3614,6 +4139,12 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"dev": true
+		},
+		"is": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
+			"integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI=",
 			"dev": true
 		},
 		"is-accessor-descriptor": {
@@ -3745,10 +4276,22 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"dev": true
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
+		},
+		"is-object": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
+			"integrity": "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc=",
 			"dev": true
 		},
 		"is-plain-object": {
@@ -3765,6 +4308,15 @@
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
 			"integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
 			"dev": true
+		},
+		"is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*"
+			}
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -3798,6 +4350,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isbuffer": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz",
+			"integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s=",
 			"dev": true
 		},
 		"isexe": {
@@ -4654,6 +5212,230 @@
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
 			"dev": true
 		},
+		"level-blobs": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/level-blobs/-/level-blobs-0.1.7.tgz",
+			"integrity": "sha1-mrm5e7mfHtv594o0M+Ie1WOGva8=",
+			"dev": true,
+			"requires": {
+				"level-peek": "1.0.6",
+				"once": "^1.3.0",
+				"readable-stream": "^1.0.26-4"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"level-filesystem": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/level-filesystem/-/level-filesystem-1.2.0.tgz",
+			"integrity": "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M=",
+			"dev": true,
+			"requires": {
+				"concat-stream": "^1.4.4",
+				"errno": "^0.1.1",
+				"fwd-stream": "^1.0.4",
+				"level-blobs": "^0.1.7",
+				"level-peek": "^1.0.6",
+				"level-sublevel": "^5.2.0",
+				"octal": "^1.0.0",
+				"once": "^1.3.0",
+				"xtend": "^2.2.0"
+			},
+			"dependencies": {
+				"xtend": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
+					"integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=",
+					"dev": true
+				}
+			}
+		},
+		"level-fix-range": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz",
+			"integrity": "sha1-vxW5Fa422EcMgh6IPd95zRZCCCg=",
+			"dev": true
+		},
+		"level-hooks": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz",
+			"integrity": "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM=",
+			"dev": true,
+			"requires": {
+				"string-range": "~1.2"
+			}
+		},
+		"level-js": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
+			"integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
+			"dev": true,
+			"requires": {
+				"abstract-leveldown": "~0.12.0",
+				"idb-wrapper": "^1.5.0",
+				"isbuffer": "~0.0.0",
+				"ltgt": "^2.1.2",
+				"typedarray-to-buffer": "~1.0.0",
+				"xtend": "~2.1.2"
+			},
+			"dependencies": {
+				"object-keys": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+					"dev": true
+				},
+				"typedarray-to-buffer": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
+					"integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw=",
+					"dev": true
+				},
+				"xtend": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+					"dev": true,
+					"requires": {
+						"object-keys": "~0.4.0"
+					}
+				}
+			}
+		},
+		"level-peek": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz",
+			"integrity": "sha1-vsUccqgu5GTTNkNMfIdsP8vM538=",
+			"dev": true,
+			"requires": {
+				"level-fix-range": "~1.0.2"
+			}
+		},
+		"level-sublevel": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz",
+			"integrity": "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo=",
+			"dev": true,
+			"requires": {
+				"level-fix-range": "2.0",
+				"level-hooks": ">=4.4.0 <5",
+				"string-range": "~1.2.1",
+				"xtend": "~2.0.4"
+			},
+			"dependencies": {
+				"level-fix-range": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz",
+					"integrity": "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug=",
+					"dev": true,
+					"requires": {
+						"clone": "~0.1.9"
+					}
+				},
+				"xtend": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
+					"integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
+					"dev": true,
+					"requires": {
+						"is-object": "~0.1.2",
+						"object-keys": "~0.2.0"
+					}
+				}
+			}
+		},
+		"levelup": {
+			"version": "0.18.6",
+			"resolved": "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz",
+			"integrity": "sha1-5qAcsIlhbI7MApHCqb0/DETj5es=",
+			"dev": true,
+			"requires": {
+				"bl": "~0.8.1",
+				"deferred-leveldown": "~0.2.0",
+				"errno": "~0.1.1",
+				"prr": "~0.0.0",
+				"readable-stream": "~1.0.26",
+				"semver": "~2.3.1",
+				"xtend": "~3.0.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+					"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "~1.0.26"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"prr": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+					"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"semver": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+					"integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI=",
+					"dev": true
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"xtend": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+					"dev": true
+				}
+			}
+		},
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4712,6 +5494,21 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"ltgt": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+			"dev": true
+		},
+		"magic-string": {
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.4"
+			}
+		},
 		"make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4760,6 +5557,17 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
+			}
+		},
+		"md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dev": true,
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"mdn-data": {
@@ -4856,6 +5664,24 @@
 				"picomatch": "^2.0.5"
 			}
 		},
+		"miller-rabin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
+			}
+		},
 		"mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -4881,6 +5707,18 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"dev": true
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
 			"dev": true
 		},
 		"minimatch": {
@@ -5116,6 +5954,17 @@
 				}
 			}
 		},
+		"object-keys": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
+			"integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
+			"dev": true,
+			"requires": {
+				"foreach": "~2.0.1",
+				"indexof": "~0.0.1",
+				"is": "~0.2.6"
+			}
+		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -5133,6 +5982,12 @@
 			"requires": {
 				"isobject": "^3.0.1"
 			}
+		},
+		"octal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/octal/-/octal-1.0.0.tgz",
+			"integrity": "sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws=",
+			"dev": true
 		},
 		"on-finished": {
 			"version": "2.3.0",
@@ -5244,6 +6099,19 @@
 				"callsites": "^3.0.0"
 			}
 		},
+		"parse-asn1": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+			"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+			"dev": true,
+			"requires": {
+				"asn1.js": "^5.2.0",
+				"browserify-aes": "^1.0.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5321,6 +6189,19 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
+		},
+		"pbkdf2": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+			"integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+			"dev": true,
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
 		},
 		"pend": {
 			"version": "1.2.0",
@@ -5423,6 +6304,18 @@
 			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
 			"dev": true
 		},
+		"process-es6": {
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/process-es6/-/process-es6-0.11.6.tgz",
+			"integrity": "sha1-xrs4n5qVH4K9TrFpYAEFvS/5x3g=",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -5455,11 +6348,39 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
+		"prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+			"dev": true
+		},
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
+		},
+		"public-encrypt": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
+			}
 		},
 		"pump": {
 			"version": "3.0.0",
@@ -5509,6 +6430,16 @@
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
 			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
 			}
 		},
@@ -5785,6 +6716,114 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
+			}
+		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dev": true,
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
+		"rollup": {
+			"version": "2.48.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.48.0.tgz",
+			"integrity": "sha512-wl9ZSSSsi5579oscSDYSzGn092tCS076YB+TQrzsGuSfYyJeep8eEWj0eaRjuC5McuMNmcnR8icBqiE/FWNB1A==",
+			"dev": true,
+			"requires": {
+				"fsevents": "~2.3.1"
+			}
+		},
+		"rollup-plugin-node-builtins": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-node-builtins/-/rollup-plugin-node-builtins-2.1.2.tgz",
+			"integrity": "sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k=",
+			"dev": true,
+			"requires": {
+				"browserify-fs": "^1.0.0",
+				"buffer-es6": "^4.9.2",
+				"crypto-browserify": "^3.11.0",
+				"process-es6": "^0.11.2"
+			}
+		},
+		"rollup-plugin-node-globals": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-node-globals/-/rollup-plugin-node-globals-1.4.0.tgz",
+			"integrity": "sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==",
+			"dev": true,
+			"requires": {
+				"acorn": "^5.7.3",
+				"buffer-es6": "^4.9.3",
+				"estree-walker": "^0.5.2",
+				"magic-string": "^0.22.5",
+				"process-es6": "^0.11.6",
+				"rollup-pluginutils": "^2.3.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+					"dev": true
+				},
+				"estree-walker": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+					"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+					"dev": true
+				},
+				"magic-string": {
+					"version": "0.22.5",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+					"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+					"dev": true,
+					"requires": {
+						"vlq": "^0.2.2"
+					}
+				}
+			}
+		},
+		"rollup-plugin-terser": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"jest-worker": "^26.2.1",
+				"serialize-javascript": "^4.0.0",
+				"terser": "^5.0.0"
+			},
+			"dependencies": {
+				"serialize-javascript": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+					"dev": true,
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				}
+			}
+		},
+		"rollup-pluginutils": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+			"dev": true,
+			"requires": {
+				"estree-walker": "^0.6.1"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+					"dev": true
+				}
 			}
 		},
 		"rsvp": {
@@ -6110,6 +7149,16 @@
 			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
 			"dev": true
 		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"shallow-clone": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
@@ -6384,6 +7433,12 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
+		"sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
+		},
 		"spawnd": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.4.0.tgz",
@@ -6531,6 +7586,12 @@
 				"char-regex": "^1.0.2",
 				"strip-ansi": "^6.0.0"
 			}
+		},
+		"string-range": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz",
+			"integrity": "sha1-qJPtNH5yKZvIO++78qaSqNI51d0=",
+			"dev": true
 		},
 		"string-width": {
 			"version": "4.2.0",
@@ -6933,6 +7994,12 @@
 				"mime-types": "~2.1.24"
 			}
 		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
 		"typedarray-to-buffer": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -7101,6 +8168,12 @@
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
 			}
+		},
+		"vlq": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+			"dev": true
 		},
 		"w3c-hr-time": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"description": "Critical CSS Generator capable of running in-browser (iframes) or on server-side (NodeJS + Puppeteer). Built for use with Jetpack Boost.",
 	"version": "0.0.1",
 	"scripts": {
+		"bundle": "rollup -c",
 		"lint": "eslint . && echo '✔ eslint ran successfully.'",
 		"lint:fix": "eslint --fix . && echo '✔ eslint ran successfully.'",
 		"test": "NODE_ENV=test jest --forceExit --detectOpenHandles"
@@ -18,6 +19,9 @@
 		"node-fetch": "^2.6.1"
 	},
 	"devDependencies": {
+		"@rollup/plugin-commonjs": "^19.0.0",
+		"@rollup/plugin-json": "^4.1.0",
+		"@rollup/plugin-node-resolve": "^13.0.0",
 		"eslint": "^7.18.0",
 		"eslint-plugin-jest": "^24.1.3",
 		"express": "^4.17.1",
@@ -29,6 +33,10 @@
 		"path-browserify": "^1.0.1",
 		"process": "^0.11.10",
 		"puppeteer": "^5.5.0",
+		"rollup": "^2.48.0",
+		"rollup-plugin-node-builtins": "^2.1.2",
+		"rollup-plugin-node-globals": "^1.4.0",
+		"rollup-plugin-terser": "^7.0.2",
 		"stream-http": "^3.1.1",
 		"webpack": "^5.19.0",
 		"webpack-cli": "^4.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,30 @@
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import json from '@rollup/plugin-json';
+import globals from 'rollup-plugin-node-globals';
+import {terser} from 'rollup-plugin-terser';
+import builtins from 'rollup-plugin-node-builtins';
+
+export default {
+	input: 'index.js',
+	output: {
+		sourcemap: true,
+		format: 'iife',
+		name: 'CriticalCSSGenerator',
+		file: 'dist/bundle.js',
+	},
+
+	plugins: [
+		resolve({ browser: true, preferBuiltins: false }),
+		commonjs( {
+			transformMixedEsModules: true
+		} ),
+		globals(),
+		builtins(),
+		json(),
+		terser()
+	],
+	watch: {
+		clearScreen: false
+	}
+};


### PR DESCRIPTION
This PR adds handy tools to bundle this library as a standalone browser-friendly bundle, using rollup.

It also updates the way Errors are converted to/from JSON to ensure their class names don't get eaten / lost by minifaction.

To use:
```
npm run bundle
```

Outputs as `dist/bundle.js`