### PR TITLE
Automatically bundle on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "0.0.1",
 	"license": "GPL-2.0-or-later",
 	"scripts": {
+		"prepare": "npm run bundle",
 		"bundle": "rollup -c",
 		"lint": "eslint . && echo '✔ eslint ran successfully.'",
 		"lint:fix": "eslint --fix . && echo '✔ eslint ran successfully.'",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "jetpack-boost-critical-css-gen",
+	"main": "./dist/bundle.js",
 	"description": "Critical CSS Generator capable of running in-browser (iframes) or on server-side (NodeJS + Puppeteer). Built for use with Jetpack Boost.",
 	"version": "0.0.1",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
This PR adds:
- An empty `.npmignore` file; without this, npm looks to `.gitignore` with disasterous results.
- Adds `"main"` to the package file, to let it know what needs to be built, and
- Adds a `prepare` script which npm can automatically run on installation.