### PR TITLE
Make sure URLs in Critical CSS are absolute

### DIFF
--- a/lib/css-file-set.js
+++ b/lib/css-file-set.js
@@ -196,6 +196,9 @@ class CSSFileSet {
 		// Parse the CSS into an AST.
 		const ast = StyleAST.parse( css );
 
+		// Make sure relative URLs in the AST are absolute.
+		ast.absolutifyUrls( cssUrl );
+
 		const file = { css, ast, pages: [ page ], urls: [ cssUrl ] };
 		this.knownUrls[ cssUrl ] = file;
 		this.cssFiles.push( file );

--- a/lib/style-ast.js
+++ b/lib/style-ast.js
@@ -33,7 +33,7 @@ class StyleAST {
 	absolutifyUrls( base ) {
 		csstree.walk( this.ast, {
 			visit: 'Url',
-			enter: ( url, item, list ) => {
+			enter: ( url ) => {
 				if ( url.value && url.value.type === 'String' ) {
 					const value = StyleAST.readValue( url.value );
 					const absolute = new URL( value, base ).toString();

--- a/lib/style-ast.js
+++ b/lib/style-ast.js
@@ -25,6 +25,29 @@ class StyleAST {
 	}
 
 	/**
+	 * Given a base URL (where the CSS file this AST was built from), find all relative URLs and
+	 * convert them to absolute.
+	 *
+	 * @param {string} base base URL for relative URLs.
+	 */
+	absolutifyUrls( base ) {
+		csstree.walk( this.ast, {
+			visit: 'Url',
+			enter: ( url, item, list ) => {
+				if ( url.value && url.value.type === 'String' ) {
+					const value = StyleAST.readValue( url.value );
+					const absolute = new URL( value, base ).toString();
+
+					if ( absolute !== value ) {
+						// URLs are encoded; " will not appear in it, so this is safe.
+						url.value.value = '"' + absolute + '"';
+					}
+				}
+			},
+		} );
+	}
+
+	/**
 	 * Returns a new StyleAST with content from this one pruned based on the specified contentWindow
 	 * and criticalSelectors to keep.
 	 *


### PR DESCRIPTION
We've had some issues with relative URLs that appear in CSS, also appearing as broken relative URLs in the Critical CSS.

For example, if your theme's stylesheet includes: 
```
body{background:url(bgpattern.png) repeat;}
```

... then `url(bgpattern.png)` will end up in the Critical CSS, directly embedded in the resultant HTML page. The problem is that `bgpattern.png` is relative to the original stylesheet; not the HTML page.

This PR fixes the issue by making sure URLs are absolute. 

**To test**
- Use the command line generator `node bin/generate.js <targetUrl>` on a site with relative URLs in the stylesheet
- Ensure the resultant Critical CSS contains a valid absolute URL in its place. 