### PR TITLE
Diagnose redirects to external site URLs

### DIFF
--- a/lib/browser-interface-iframe.js
+++ b/lib/browser-interface-iframe.js
@@ -87,14 +87,16 @@ class BrowserInterfaceIframe extends BrowserInterface {
 
 	async diagnoseUrlError( url ) {
 		try {
-			const response = await fetch( url );
+			const response = await fetch( url, { redirect: 'manual' } );
+
+			if ( response.type === 'opaqueredirect' ) {
+				return new RedirectError( {
+					url,
+					redirectUrl: response.url,
+				} );
+			}
+
 			if ( response.status === 200 ) {
-				if ( response.redirected ) {
-					return new RedirectError( {
-						url,
-						redirectUrl: response.url,
-					} );
-				}
 				return null;
 			}
 
@@ -132,7 +134,10 @@ class BrowserInterfaceIframe extends BrowserInterface {
 
 					// Verify the inner document is readable.
 					if ( ! this.iframe.contentDocument ) {
-						throw new CrossDomainError( { url: fullUrl } );
+						throw (
+							( await this.diagnoseUrlError( fullUrl ) ) ||
+							new CrossDomainError( { url: fullUrl } )
+						);
 					}
 
 					if (


### PR DESCRIPTION
When a page redirects to an external URL, it can cause an opaque "Cross Domain" error. e.g.:
`Failed to fetch cross-domain content at <url>`

This error gets thrown when we are unable to read the document inside an iframe after it has finished loading. But it's more useful to tell the user about redirects to external URLs. So, this PR addresses that issue by explicitly detecting redirects.

When unable to read the contents of the generator iframe, it now runs a `fetch` request (via `diagnoseUrlError`, which now supports detecting redirects to cross-domain targets). It will now throw a `RedirectError`, giving a more detailed / useful error to users. i.e.:
```
Failed to process <url/> because it redirects to <other url/> which cannot be verified.
```

Or, as expressed in the Jetpack Boost plugin:
```
The following URL is redirecting to a different page, preventing Critical CSS from being generated: <url/>
```

**Testing**
The easiest way to test this is inside the Jetpack Boost plugin. Install a plugin like `redirection` and set up a rule to redirect a lot of pages to an external URL like `http://example.com`. Attempt to generate Critical CSS, and verify the redirect error is thrown.