### PR TITLE
Throw an error if Critical CSS is empty

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -113,6 +113,19 @@ class UrlVerifyError extends UrlError {
 	}
 }
 
+/**
+ * EmptyCSSError - Indicates that a requested URL does not have any CSS in its external style sheet(s) and therefore Critical CSS could not be generated.
+ */
+class EmptyCSSError extends UrlError {
+	constructor( { url } ) {
+		super(
+			'EmptyCSSError',
+			{ url },
+			`The ${ url } does not have any CSS in its external style sheet(s).`
+		);
+	}
+}
+
 module.exports = {
 	SuccessTargetError,
 	UrlError,
@@ -122,4 +135,5 @@ module.exports = {
 	LoadTimeoutError,
 	RedirectError,
 	UrlVerifyError,
+	EmptyCSSError,
 };

--- a/lib/generate-critical-css.js
+++ b/lib/generate-critical-css.js
@@ -1,7 +1,7 @@
 const CSSFileSet = require( './css-file-set' );
 const { removeIgnoredPseudoElements } = require( './ignored-pseudo-elements' );
 const { minifyCss } = require( './minify-css' );
-const { SuccessTargetError } = require( './errors' );
+const { SuccessTargetError, EmptyCSSError } = require( './errors' );
 const { BrowserInterface } = require( './browser-interface' );
 
 /**
@@ -179,6 +179,15 @@ async function generateCriticalCSS( {
 		const [ css, cssErrors ] = minifyCss(
 			asts.map( ( ast ) => ast.toCSS() ).join( '\n' )
 		);
+
+		// If there is no Critical CSS, it means the URLs did not have any CSS in their external style sheet(s).
+		if ( ! css ) {
+			const emptyCSSErrors = {};
+			for ( const url of validUrls ) {
+				emptyCSSErrors[ url ] = new EmptyCSSError( { url } );
+			}
+			throw new SuccessTargetError( emptyCSSErrors );
+		}
 
 		// Collect warnings / errors together.
 		const warnings = cssFiles.getErrors().concat( cssErrors );


### PR DESCRIPTION
This is a redo of https://github.com/Automattic/jetpack-boost-critical-css-gen/pull/17 following the refactoring from the "[Simplify Error Reporting](https://github.com/Automattic/jetpack-boost-critical-css-gen/pull/18)" PR.

See https://github.com/Automattic/jetpack/pull/20585 for more context