### PR TITLE
Fixes Deny x-frame-options Automattic/jetpack#21023

### DIFF
--- a/lib/browser-interface-iframe.js
+++ b/lib/browser-interface-iframe.js
@@ -6,6 +6,7 @@ const {
 	RedirectError,
 	UrlVerifyError,
 	UnknownError,
+	XFrameDenyError
 } = require( './errors' );
 
 const defaultLoadTimeout = 60 * 1000;
@@ -85,6 +86,11 @@ class BrowserInterfaceIframe extends BrowserInterface {
 	async diagnoseUrlError( url ) {
 		try {
 			const response = await fetch( url, { redirect: 'manual' } );
+			const headers = response.headers;
+
+			if( headers.get( 'x-frame-options' ) === 'DENY' ) {
+				return new XFrameDenyError( url );
+			}
 
 			if ( response.type === 'opaqueredirect' ) {
 				return new RedirectError( {

--- a/lib/browser-interface-iframe.js
+++ b/lib/browser-interface-iframe.js
@@ -89,7 +89,7 @@ class BrowserInterfaceIframe extends BrowserInterface {
 			const headers = response.headers;
 
 			if( headers.get( 'x-frame-options' ) === 'DENY' ) {
-				return new XFrameDenyError( url );
+				return new XFrameDenyError( { url } );
 			}
 
 			if ( response.type === 'opaqueredirect' ) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -131,7 +131,7 @@ class EmptyCSSError extends UrlError {
  */
  class XFrameDenyError extends UrlError {
 	constructor( { url } ) {
-		super( 'XFrameDenyError', { url }, `Failed to process because of x-frame-options deny configration` );
+		super( 'XFrameDenyError', { url }, `Failed to load ${ url } due to the "X-Frame-Options: DENY" header` );
 	}
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -126,6 +126,15 @@ class EmptyCSSError extends UrlError {
 	}
 }
 
+/**
+ * XFrameDenyError - Indicates that a requested URL failed due to x-frame-options deny configuration
+ */
+ class XFrameDenyError extends UrlError {
+	constructor( { url } ) {
+		super( 'XFrameDenyError', { url }, `Failed to process because of x-frame-options deny configration` );
+	}
+}
+
 module.exports = {
 	SuccessTargetError,
 	UrlError,
@@ -136,4 +145,5 @@ module.exports = {
 	RedirectError,
 	UrlVerifyError,
 	EmptyCSSError,
+	XFrameDenyError
 };


### PR DESCRIPTION
### Changes Proposed in the PR

* In this commit I have updated `diagnoseUrlError` to handle
`x-frame-options: deny` configuration
* Created a new error class for better readability

### Screenshot
![Screenshot from 2021-09-10 22-23-39](https://user-images.githubusercontent.com/21127788/132889786-c34885be-cf53-4b1c-baee-b377b0292e19.png)

### Testing Instruction
* Replace line number 11 to `"jetpack-boost-critical-css-gen": "github:amustaque97/jetpack-boost-critical-css-gen#fix\/detect-xframe-options"` https://github.com/Automattic/jetpack/blob/master/projects/plugins/boost/package.json#L11
*  Navigate to jetpack repo/directory
* Build jetpack boost plugin `jetpack build`
* Open file `jetpack/tools/docker/wordpress/wp-config.php`
* At the end of the file add this line `header('X-Frame-Options: DENY');`
*  Run `jetpack docker up`
* Open local WordPress in browser
* Open jetpack boost and enable critical CSS
* Click on `See error message`

Fixes automattic/jetpack#21023