### PR TITLE
Fix bad font node with condition check

### DIFF
--- a/lib/style-ast.js
+++ b/lib/style-ast.js
@@ -443,7 +443,10 @@ class StyleAST {
 						const property = csstree.property(
 							declaration.property
 						).name;
-						if ( [ 'src', 'font-family' ].includes( property ) ) {
+						if (
+							[ 'src', 'font-family' ].includes( property ) &&
+							'children' in declaration.value
+						) {
 							const values = declaration.value.children.toArray();
 							properties[ property ] = values.map(
 								StyleAST.readValue


### PR DESCRIPTION
### Issue description
The user reported that they are getting the following error:
> Can not read properties of undefined (reading toArray)

Issue discussion: archives/C016BBAFHHS/p1632764258016400

### Changes proposed in this Pull Request:
Add a check of the existence of `children` property on declaration value.
Thanks, @thingalon for help solving the issue.

### Testing instructions:
1. Add the following declaration on an external CSS sheet in a website where the tests are being run:

    ```
    @font-face {
    	src: );
    }
    ```
2. Run `node bin/generate {url}`

    That should throw the error:
    > Can not read properties of undefined (reading toArray)

3. Update the patch from this PR and run the generation again.
4. There should not be any errors.

**Note:** Lint errors in this PR already has a fix on #21