### PR TITLE
Add fetch interface

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,9 @@
 	"extends": [
 		"eslint:recommended",
 		"plugin:@wordpress/eslint-plugin/recommended"
-	]
+	],
+	"rules": {
+		"no-unused-vars": [ "error", { "args": "after-used", "argsIgnorePattern": "^_" }]
+	}
 }
 

--- a/lib/browser-interface-iframe.js
+++ b/lib/browser-interface-iframe.js
@@ -61,6 +61,18 @@ class BrowserInterfaceIframe extends BrowserInterface {
 		this.wrapperDiv.remove();
 	}
 
+	/**
+	 * Wrapper for window.fetch. Overload this to change CSS or HTML fetching
+	 * behaviour.
+	 *
+	 * @param {string} url URL to fetch.
+	 * @param {Object} options Fetch options.
+	 * @param {string} _role 'css' or 'html' indicating what kind of thing is being fetched.
+	 */
+	async fetch( url, options, _role ) {
+		return window.fetch( url, options );
+	}
+
 	async runInPage( pageUrl, viewport, method, ...args ) {
 		await this.loadPage( pageUrl );
 
@@ -85,7 +97,11 @@ class BrowserInterfaceIframe extends BrowserInterface {
 
 	async diagnoseUrlError( url ) {
 		try {
-			const response = await fetch( url, { redirect: 'manual' } );
+			const response = await this.fetch(
+				url,
+				{ redirect: 'manual' },
+				'html'
+			);
 			const headers = response.headers;
 
 			if ( headers.get( 'x-frame-options' ) === 'DENY' ) {

--- a/lib/browser-interface-puppeteer.js
+++ b/lib/browser-interface-puppeteer.js
@@ -26,6 +26,19 @@ class BrowserInterfacePuppeteer extends BrowserInterface {
 		// Call inner method within the puppeteer context.
 		return page.evaluate( method, window, ...args );
 	}
+
+	/**
+	 * Replacement for browser.fetch, uses node-fetch to simulate the same
+	 * interface.
+	 *
+	 * @param {string} url URL to fetch.
+	 * @param {Object} options Fetch options.
+	 * @param {string} _role 'css' or 'html' indicating what kind of thing is being fetched.
+	 */
+	async fetch( url, options, _role ) {
+		const nodeFetch = require( 'node-fetch' );
+		return nodeFetch( url, options );
+	}
 }
 
 module.exports = BrowserInterfacePuppeteer;

--- a/lib/browser-interface.js
+++ b/lib/browser-interface.js
@@ -18,6 +18,20 @@ class BrowserInterface {
 		);
 	}
 
+	/**
+	 * Context-specific wrapper for fetch; uses window.fetch in browsers, or a
+	 * node library when using Puppeteer.
+	 *
+	 * @param {string} _url URL to fetch.
+	 * @param {Object} _options Fetch options.
+	 * @param {string} _role 'css' or 'html' indicating what kind of thing is being fetched.
+	 */
+	async fetchCss( _url, _options, _role ) {
+		throw new Error(
+			'Undefined interface method: BrowserInterface.fetchCss()'
+		);
+	}
+
 	async cleanup() {}
 
 	async getCssIncludes( pageUrl ) {

--- a/lib/browser-interface.js
+++ b/lib/browser-interface.js
@@ -26,7 +26,7 @@ class BrowserInterface {
 	 * @param {Object} _options Fetch options.
 	 * @param {string} _role 'css' or 'html' indicating what kind of thing is being fetched.
 	 */
-	async fetchCss( _url, _options, _role ) {
+	async fetch( _url, _options, _role ) {
 		throw new Error(
 			'Undefined interface method: BrowserInterface.fetchCss()'
 		);

--- a/lib/browser-interface.js
+++ b/lib/browser-interface.js
@@ -28,7 +28,7 @@ class BrowserInterface {
 	 */
 	async fetch( _url, _options, _role ) {
 		throw new Error(
-			'Undefined interface method: BrowserInterface.fetchCss()'
+			'Undefined interface method: BrowserInterface.fetch()'
 		);
 	}
 

--- a/lib/css-file-set.js
+++ b/lib/css-file-set.js
@@ -13,7 +13,8 @@ const maxVarPruneIterations = 10;
  * all errors that occur while loading or parsing CSS.
  */
 class CSSFileSet {
-	constructor() {
+	constructor( browserInterface ) {
+		this.browserInterface = browserInterface;
 		this.knownUrls = {};
 		this.cssFiles = [];
 		this.errors = [];
@@ -54,7 +55,11 @@ class CSSFileSet {
 
 		// Try to load this URL.
 		try {
-			const response = await fetch( cssUrl );
+			const response = await this.browserInterface.fetch(
+				cssUrl,
+				{},
+				'css'
+			);
 			if ( ! response.ok ) {
 				throw new HttpError( { code: response.code, url: cssUrl } );
 			}

--- a/lib/css-file-set.js
+++ b/lib/css-file-set.js
@@ -1,8 +1,5 @@
 const { HttpError, UnknownError, UrlError } = require( './errors' );
 const StyleAST = require( './style-ast' );
-const fetch =
-	( typeof window !== 'undefined' && window.fetch ) ||
-	require( 'node-fetch' );
 
 // Maximum number of iterations when pruning unused variables.
 const maxVarPruneIterations = 10;

--- a/lib/generate-critical-css.js
+++ b/lib/generate-critical-css.js
@@ -16,7 +16,7 @@ const BrowserInterface = require( './browser-interface' );
  * @return {Array} - Two member array; CSSFileSet, and an object containing errors that occurred at each URL.
  */
 async function collateCssFiles( browserInterface, urls, successUrlsThreshold ) {
-	const cssFiles = new CSSFileSet();
+	const cssFiles = new CSSFileSet( browserInterface );
 	const errors = {};
 	let successes = 0;
 


### PR DESCRIPTION
Move fetch calls into the `BrowserInterface` heirarchy, to allow callers to override fetch behaviour for CSS / HTML files.

To test
1. Ensure that this still works with Puppeteer using `bin/generate.js`
2. Ensure this still works in an iframe context by using it with Jetpack Boost.