### PR TITLE
Remove @keyframe definitions from output

### DIFF
--- a/lib/generate-critical-css.js
+++ b/lib/generate-critical-css.js
@@ -189,10 +189,15 @@ async function generateCriticalCSS( {
 		// Collect warnings / errors together.
 		const warnings = cssFiles.getErrors().concat( cssErrors );
 
-		return [ css, warnings ];
+		return [ cleanupCSS( css ), warnings ];
 	} finally {
 		browserInterface.cleanup();
 	}
+}
+
+function cleanupCSS( css ) {
+	// Remove keyframe animations.
+	return css.replace( /@[\w-]*?keyframes\s+[\w-]*\s*\{.*?\}\s*\}/gis, '' );
 }
 
 module.exports = generateCriticalCSS;

--- a/lib/generate-critical-css.js
+++ b/lib/generate-critical-css.js
@@ -189,15 +189,10 @@ async function generateCriticalCSS( {
 		// Collect warnings / errors together.
 		const warnings = cssFiles.getErrors().concat( cssErrors );
 
-		return [ cleanupCSS( css ), warnings ];
+		return [ css, warnings ];
 	} finally {
 		browserInterface.cleanup();
 	}
-}
-
-function cleanupCSS( css ) {
-	// Remove keyframe animations.
-	return css.replace( /@[\w-]*?keyframes\s+[\w-]*\s*\{.*?\}\s*\}/gis, '' );
 }
 
 module.exports = generateCriticalCSS;

--- a/lib/style-ast.js
+++ b/lib/style-ast.js
@@ -6,6 +6,7 @@ const stringPattern = /^(["']).*\1$/;
 const maxBase64Length = 1000;
 const excludedSelectors = [ /::?(?:-moz-)?selection/ ];
 const excludedProperties = [
+	/(.*)animation/,
 	/(.*)transition(.*)/,
 	/cursor/,
 	/pointer-events/,

--- a/lib/style-ast.js
+++ b/lib/style-ast.js
@@ -274,15 +274,10 @@ class StyleAST {
 		csstree.walk( this.ast, {
 			visit: 'Atrule',
 			enter: ( atrule, atitem, atlist ) => {
-				// Ignore non-keyframe and invalid atrules.
-				if (
-					csstree.keyword( atrule.name ).basename !== 'keyframes' ||
-					! atrule.prelude
-				) {
-					return;
+				// Ignore non-keyframes.
+				if ( csstree.keyword( atrule.name ).basename === 'keyframes' ) {
+					atlist.remove( atitem );
 				}
-
-				atlist.remove( atitem );
 			},
 		} );
 	}

--- a/lib/style-ast.js
+++ b/lib/style-ast.js
@@ -70,6 +70,7 @@ class StyleAST {
 		);
 
 		clone.pruneMediaQueries();
+		clone.pruneKeyframes();
 		clone.pruneNonCriticalSelectors( criticalSelectors );
 		clone.pruneExcludedProperties();
 		clone.pruneLargeBase64Embeds();
@@ -261,6 +262,26 @@ class StyleAST {
 				) {
 					atlist.remove( atitem );
 				}
+			},
+		} );
+	}
+
+	/**
+	 * Remove keyframe definitions.
+	 */
+	pruneKeyframes() {
+		csstree.walk( this.ast, {
+			visit: 'Atrule',
+			enter: ( atrule, atitem, atlist ) => {
+				// Ignore non-keyframe and invalid atrules.
+				if (
+					csstree.keyword( atrule.name ).basename !== 'keyframes' ||
+					! atrule.prelude
+				) {
+					return;
+				}
+
+				atlist.remove( atitem );
 			},
 		} );
 	}


### PR DESCRIPTION
Fixes #26

Remove all @keyframe, @-webkit-keyframe and alike from CSS output.