### PR TITLE
Preserve inline variables

### DIFF
--- a/src/browser-interface-playwright.ts
+++ b/src/browser-interface-playwright.ts
@@ -2,9 +2,10 @@ import { Viewport } from './types';
 import { BrowserInterface, BrowserRunnable, FetchOptions } from './browser-interface';
 
 interface Page {
-	setViewportSize( viewport: Viewport ): Promise<void>;
+	setViewportSize( viewport: Viewport ): Promise< void >;
+	// eslint-disable-next-line @typescript-eslint/ban-types
 	evaluate( method: string | Function, arg: Record< string, unknown > );
-};
+}
 
 export class BrowserInterfacePlaywright extends BrowserInterface {
 	constructor( private pages: { [ url: string ]: Page } ) {

--- a/src/browser-interface-puppeteer.ts
+++ b/src/browser-interface-puppeteer.ts
@@ -2,9 +2,10 @@ import { Viewport } from './types';
 import { BrowserInterface, BrowserRunnable, FetchOptions } from './browser-interface';
 
 interface Page {
-	setViewport( viewport: Viewport ): Promise<void>;
+	setViewport( viewport: Viewport ): Promise< void >;
+	// eslint-disable-next-line @typescript-eslint/ban-types
 	evaluate( method: string | Function, arg: Record< string, unknown > );
-};
+}
 
 export class BrowserInterfacePuppeteer extends BrowserInterface {
 	constructor( private pages: { [ url: string ]: Page } ) {

--- a/src/browser-interface.ts
+++ b/src/browser-interface.ts
@@ -80,8 +80,8 @@ export class BrowserInterface {
 	/**
 	 * Get all internal styles as a combined string from the window.
 	 *
-	 * @param  root0
-	 * @param  root0.innerWindow
+	 * @param {Object} wrappedArgs
+	 * @param {Window} wrappedArgs.innerWindow - Window inside the browser interface.
 	 */
 	static innerGetInternalStyles( { innerWindow } ): string {
 		innerWindow = null === innerWindow ? window : innerWindow;

--- a/src/browser-interface.ts
+++ b/src/browser-interface.ts
@@ -73,6 +73,26 @@ export class BrowserInterface {
 			}, {} );
 	}
 
+	async getInternalStyles( pageUrl: string ): Promise< string > {
+		return await this.runInPage( pageUrl, null, BrowserInterface.innerGetInternalStyles );
+	}
+
+	/**
+	 * Get all internal styles as a combined string from the window.
+	 *
+	 * @param  root0
+	 * @param  root0.innerWindow
+	 */
+	static innerGetInternalStyles( { innerWindow } ): string {
+		innerWindow = null === innerWindow ? window : innerWindow;
+		const styleElements = Array.from( innerWindow.document.getElementsByTagName( 'style' ) );
+
+		return styleElements.reduce( ( styles: string, style: HTMLStyleElement ) => {
+			styles += style.innerText;
+			return styles;
+		}, '' ) as string;
+	}
+
 	/**
 	 * Given a set of CSS selectors (as object keys), along with "simplified" versions
 	 * for easy querySelector calling (values), return an array of selectors which match

--- a/src/generate-critical-css.ts
+++ b/src/generate-critical-css.ts
@@ -44,6 +44,9 @@ async function collateCssFiles(
 
 			await cssFiles.addMultiple( url, absoluteIncludes );
 
+			const internalStyles = await browserInterface.getInternalStyles( url );
+			await cssFiles.addInternalStyles( url, internalStyles );
+
 			// Abort early if we hit the threshold of success urls.
 			successes++;
 			if ( successes >= successUrlsThreshold ) {


### PR DESCRIPTION
Fixes Automattic/jetpack#25695
Account for variable usage in internal CSS while pruning unused variables.

## Test
I have created a codesandbox to test this. https://codesandbox.io/s/boring-framework-9lyn9s
1. Try generating critical CSS for the codesandbox site: `npm run gen https://9lyn9s.csb.app/`
2. The resulting output should be: `h1{--text-color:#00d200;font-size:20px}`. This kept the variable for `h1` but removed it for `p` as that is outside the viewport.