### PR TITLE
Avoid reloading the same URL when running in an iframe

### DIFF
--- a/src/browser-interface-iframe.ts
+++ b/src/browser-interface-iframe.ts
@@ -183,6 +183,7 @@ export class BrowserInterfaceIframe extends BrowserInterface {
 						);
 					}
 
+					this.currentUrl = rawUrl;
 					resolve();
 				} catch ( err ) {
 					reject( err );


### PR DESCRIPTION
When running in an iframe, the same URL was reloaded multiple times unnecessarily. This PR fixes the issue by keeping track of which  URL is currently in the iframe to prevent reloading. :)