### PR TITLE
Update local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ To get around this issue, we can use `yalc` and do some customization to make de
 - Go to your jetpack boost folder (`jetpack/projects/packages/boost`).
 - Run `yalc link jetpack-boost-critical-css-gen` to link from this the dependency to this library.
 - Now every time you want to sync changes, use `yalc push` from this library.
+
+See: pc9hqz-1NI-p2

--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ async function playwrightGenerator( urls: string[] ): Promise< string > {
 	- The release title will be the same as the tag.
 	- Click "Generate release notes" to automatically generate new release note.
 	- Publish
+
+# Local development
+Since we generally do development in docker, it is hard to test this with Jetpack Boost. `npm link` does not work in this case.
+To get around this issue, we can use `yalc` and do some customization to make development and testing easy. Here is what to do:
+
+- Run `npm -g yalc` to install yalc globally.
+- Run `yalc publish` from this package directory to publish this locally as a yalc repository.
+- Go to your jetpack boost folder (`jetpack/projects/packages/boost`).
+- Run `yalc link jetpack-boost-critical-css-gen` to link from this the dependency to this library.
+- Now every time you want to sync changes, use `yalc push` from this library.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jetpack-boost-critical-css-gen",
-	"version": "0.0.6",
+	"version": "0.0.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jetpack-boost-critical-css-gen",
-			"version": "0.0.6",
+			"version": "0.0.9",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"clean-css": "^5.3.1",


### PR DESCRIPTION
Make local development easier by making it easy to sync changes with Boost plugin and boost-cloud.

Need to merge the following PRs to make this work:
- Automattic/boost-cloud#270
- Automattic/jetpack#31371