### PR TITLE
Remove `@charset` and `@import` rules when building CSS

### DIFF
--- a/src/style-ast.ts
+++ b/src/style-ast.ts
@@ -75,7 +75,7 @@ export class StyleAST {
 		const clone = new StyleAST( this.css, csstree.clone( this.ast ), this.errors );
 
 		clone.pruneMediaQueries();
-		clone.pruneKeyframes();
+		clone.pruneAtRules();
 		clone.pruneNonCriticalSelectors( criticalSelectors );
 		clone.pruneExcludedProperties();
 		clone.pruneLargeBase64Embeds();
@@ -256,14 +256,16 @@ export class StyleAST {
 	}
 
 	/**
-	 * Remove keyframe definitions.
+	 * Remove atrules which are incompatible with Critical CSS.
+	 * Targets keyframes (for animations), charsets and imports.
 	 */
-	pruneKeyframes(): void {
+	pruneAtRules(): void {
+		const prune = [ 'keyframes', 'charset', 'import' ];
+
 		csstree.walk( this.ast, {
 			visit: 'Atrule',
 			enter: ( atrule, atitem, atlist ) => {
-				// Ignore non-keyframes.
-				if ( csstree.keyword( atrule.name ).basename === 'keyframes' ) {
+				if ( prune.includes( csstree.keyword( atrule.name ).basename ) ) {
 					atlist.remove( atitem );
 				}
 			},

--- a/src/style-ast.ts
+++ b/src/style-ast.ts
@@ -75,7 +75,7 @@ export class StyleAST {
 		const clone = new StyleAST( this.css, csstree.clone( this.ast ), this.errors );
 
 		clone.pruneMediaQueries();
-		clone.pruneAtRules();
+		clone.pruneAtRules( [ 'keyframes', 'charset', 'import' ] );
 		clone.pruneNonCriticalSelectors( criticalSelectors );
 		clone.pruneExcludedProperties();
 		clone.pruneLargeBase64Embeds();
@@ -256,16 +256,15 @@ export class StyleAST {
 	}
 
 	/**
-	 * Remove atrules which are incompatible with Critical CSS.
-	 * Targets keyframes (for animations), charsets and imports.
+	 * Remove unwanted at-rules.
+	 *
+	 * @param { string[] } names - Names of at-rules to remove, excluding the at symbol.
 	 */
-	pruneAtRules(): void {
-		const prune = [ 'keyframes', 'charset', 'import' ];
-
+	pruneAtRules( names: string[] ): void {
 		csstree.walk( this.ast, {
 			visit: 'Atrule',
 			enter: ( atrule, atitem, atlist ) => {
-				if ( prune.includes( csstree.keyword( atrule.name ).basename ) ) {
+				if ( names.includes( csstree.keyword( atrule.name ).basename ) ) {
 					atlist.remove( atitem );
 				}
 			},


### PR DESCRIPTION
`@charset` rules can only appear at the very beginning of any CSS block and are technically invalid anywhere else. As Critical CSS joins multiple files together, it's cleaner to strip `charset` rules. Technically charset rules are only needed for non-utf8 stylesheets, which are vanishingly rare. 

On testing, it appears that non-utf8 stylesheets are currently not supported anyway, so we don't lose anything by stripping the tags. If we come across sites with non-utf8 stylesheets, we can consider adding explicit support down the road.

This update also strips out `@import` directives - both because they are also fussy about where they appear in a CSS file, and because by the time you `@import` something you are waiting on a resource to load - so it has no business in a Critical CSS block.

*** To test ***

I recommend using @haqadn's yalc setup to test the change in Boost - pc9hqz-1NI-p2 - and verify that no `@charset` rules appear in the resultant Critical CSS block.